### PR TITLE
feat(lua/install): add lua backend, python venv isolation, and automated configuration

### DIFF
--- a/backend/downloads.py
+++ b/backend/downloads.py
@@ -1005,18 +1005,29 @@ def _get_launcher_path_file() -> str:
     return os.path.join(os.path.dirname(__file__), "data", "launcher_path.txt")
 
 def load_launcher_path() -> str:
-    """Lê o caminho do launcher salvo. Se não existir, retorna o padrão do Bifrost."""
-    default_path = os.path.expanduser("~/.local/share/Bifrost/bin/Bifrost")
+    """Lê o caminho do launcher salvo. Se não existir, tenta encontrar o ACCELA automaticamente, caso contrário retorna o padrão do Bifrost."""
     try:
         path_file = _get_launcher_path_file()
         if os.path.exists(path_file):
             with open(path_file, "r", encoding="utf-8") as f:
                 saved_path = f.read().strip()
-                if saved_path:
+                if saved_path and os.path.exists(saved_path):
                     return saved_path
     except Exception as e:
         logger.warn(f"LuaTools: Erro ao ler caminho do launcher: {e}")
-    return default_path
+
+    # Fallback automático para o ACCELA (AppImage ou run.sh)
+    accela_candidates = [
+        os.path.expanduser("~/.local/share/ACCELA/ACCELA.AppImage"),
+        os.path.expanduser("~/.local/share/ACCELA/run.sh"),
+        os.path.expanduser("~/accela/ACCELA.AppImage"),
+        os.path.expanduser("~/accela/run.sh"),
+    ]
+    for cand in accela_candidates:
+        if os.path.exists(cand):
+            return cand
+
+    return os.path.expanduser("~/.local/share/Bifrost/bin/Bifrost")
 
 def save_launcher_path_config(path: str) -> str:
     """Salva o caminho do launcher escolhido pelo usuário."""

--- a/backend/main.lua
+++ b/backend/main.lua
@@ -1,0 +1,131 @@
+local millennium = require("millennium")
+local fs = require("fs")
+local logger = require("logger")
+
+local function write_file(path, content)
+local f = io.open(path, "w")
+if not f then
+    logger:warn("LuaTools: failed to write " .. path)
+    return false
+    end
+    f:write(content)
+    f:close()
+    return true
+    end
+
+    local function find_plugin_dir()
+    local home = os.getenv("HOME") or ""
+    local candidates = {
+        fs.join(home, ".local", "share", "millennium", "plugins", "luatools"),
+        fs.join(millennium.get_install_path(), "plugins", "luatools"),
+    }
+    for _, dir in ipairs(candidates) do
+        if fs.exists(fs.join(dir, "public", "luatools.js")) then
+            return dir
+            end
+            end
+            return candidates[1]
+            end
+
+            local function on_load()
+            local steam_path = millennium.steam_path():gsub("/+$", "")
+            local plugin_dir = find_plugin_dir()
+            logger:info("LuaTools: plugin_dir=" .. plugin_dir)
+
+            local dest_dir = fs.join(steam_path, "steamui", "LuaTools")
+            if not fs.exists(dest_dir) then
+                local ok, err = fs.create_directories(dest_dir)
+                if not ok then
+                    logger:warn("LuaTools: failed to create " .. dest_dir .. ": " .. (err or "unknown"))
+                    end
+                    end
+
+                    local src_js = fs.join(plugin_dir, "public", "luatools.js")
+                    local dst_js = fs.join(dest_dir, "luatools.js")
+                    if fs.exists(src_js) then
+                        local ok2, err2 = fs.copy(src_js, dst_js, false)
+                        if not ok2 then
+                            logger:warn("LuaTools: copy failed: " .. (err2 or "unknown"))
+                            end
+                            end
+
+                            local src_icon = fs.join(plugin_dir, "public", "luatools-icon.png")
+                            local dst_icon = fs.join(dest_dir, "luatools-icon.png")
+                            if fs.exists(src_icon) then
+                                fs.copy(src_icon, dst_icon, false)
+                                end
+
+                                local src_themes = fs.join(plugin_dir, "public", "themes")
+                                local dst_themes = fs.join(dest_dir, "themes")
+                                if fs.exists(src_themes) then
+                                    fs.copy_recursive(src_themes, dst_themes, false)
+                                    end
+
+                                    local bridge_path = fs.join(dest_dir, "luatools_bridge.js")
+                                    local bridge_js = [[
+                                        (function(){
+                                            if (typeof window === 'undefined') return;
+                                            window.Millennium = window.Millennium || {};
+                                            window.Millennium.callServerMethod = function(plugin, method, args) {
+                                                var payload = {
+                                                    method: String(method || ''),
+                                         args: (args && typeof args === 'object') ? args : {}
+                                                };
+                                                return fetch('http://127.0.0.1:38495/rpc', {
+                                                    method: 'POST',
+                                                    headers: { 'Content-Type': 'application/json' },
+                                                    body: JSON.stringify(payload)
+                                                }).then(function(res) {
+                                                    if (!res || !res.ok) {
+                                                        throw new Error('LuaTools bridge unavailable');
+                                                    }
+                                                    return res.json();
+                                                }).then(function(body) {
+                                                    if (!body || body.success !== true) {
+                                                        throw new Error((body && body.error) ? String(body.error) : 'RPC failed');
+                                                    }
+                                                    return body.result;
+                                                });
+                                            };
+                                        })();
+                                    ]]
+                                    write_file(bridge_path, bridge_js)
+
+                                    millennium.add_browser_js("LuaTools/luatools_bridge.js")
+                                    millennium.add_browser_js("LuaTools/luatools.js")
+
+                                    local venv_dir = fs.join(plugin_dir, ".venv")
+                                    local venv_python = fs.join(venv_dir, "bin", "python3")
+                                    local bridge_py = fs.join(plugin_dir, "backend", "web_bridge_server.py")
+                                    local requirements = fs.join(plugin_dir, "requirements.txt")
+
+                                    local bash_script = string.format([[
+                                        set -e
+                                        if [ ! -f "%s" ]; then
+                                            python3 -m venv "%s" || true
+                                            fi
+                                            if [ -f "%s" ]; then
+                                                "%s" -m pip install --quiet --disable-pip-version-check -r "%s" || true
+                                                fi
+                                                exec "%s" "%s"
+                                    ]], venv_python, venv_dir, requirements, venv_python, requirements, venv_python, bridge_py)
+
+                                    local safe_bash = bash_script:gsub("'", "'\\''")
+                                    local final_command = "nohup bash -c '" .. safe_bash .. "' > /tmp/luatools_bridge.log 2>&1 &"
+
+                                    os.execute(final_command)
+
+                                    logger:info("LuaTools bridge starting via bash -c, Millennium " .. millennium.version())
+
+                                    millennium.ready()
+                                    end
+
+                                    local function on_unload()
+                                    os.execute("pkill -f web_bridge_server.py 2>/dev/null || true")
+                                    logger:info("LuaTools unloaded")
+                                    end
+
+                                    return {
+                                        on_load = on_load,
+                                        on_unload = on_unload
+                                    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -380,13 +380,24 @@ def UpdateMorrenusKey(key: str, contentScriptQuery: str = "") -> str:
 
 def GetLauncherPath(contentScriptQuery: str = "") -> str:
     path = load_launcher_path()
-    accela_default = os.path.expanduser("~/.local/share/ACCELA/run.sh")
 
-    # Se o caminho salvo for do Bifrost OU estiver vazio OU não existir, força o ACCELA
+    # Se o caminho salvo for do Bifrost OU estiver vazio OU não existir, tenta encontrar o ACCELA automaticamente
     if not path or "Bifrost" in path or not os.path.exists(path):
-        path = accela_default if os.path.exists(accela_default) else "/home/deck/.local/share/ACCELA/run.sh"
-        # Opcional: Descomente a linha abaixo se quiser que ele salve no .txt automaticamente
-        # save_launcher_path_config(path)
+        accela_candidates = [
+            os.path.expanduser("~/.local/share/ACCELA/ACCELA.AppImage"),
+            os.path.expanduser("~/.local/share/ACCELA/run.sh"),
+            os.path.expanduser("~/accela/ACCELA.AppImage"),
+            os.path.expanduser("~/accela/run.sh"),
+        ]
+        detected = ""
+        for cand in accela_candidates:
+            if os.path.exists(cand):
+                detected = cand
+                break
+        if detected:
+            path = detected
+        else:
+            path = os.path.expanduser("~/.local/share/ACCELA/run.sh") # fallback
 
     return json.dumps({"success": True, "path": path})
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1272,7 +1272,7 @@ def GetSLSPlayStatus(contentScriptQuery: str = "") -> str:
         with open(config_path, 'r', encoding='utf-8') as f:
             content = f.read()
             # Verifica se está configurado como 'yes'
-            is_enabled = "PlayNotOwnedGames: yes" in content.lower()
+            is_enabled = "playnotownedgames: yes" in content.lower() or "playnotownedgames: true" in content.lower()
             return json.dumps({"success": True, "enabled": is_enabled})
     except Exception as e:
         return json.dumps({"success": False, "error": str(e)})

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 DEBUG=false
+INSTALL_LOCAL=false
 info() { echo -e "${CYAN}[INFO]${NC} $*"; }
 ok() { echo -e "${GREEN}[ OK ]${NC} $*"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
@@ -57,20 +58,42 @@ PY
 
 # ---------- Install plugin from GitHub release ----------
 install_plugin_from_release() {
-    info "Installing LuaTools plugin from latest GitHub release..."
-    if ! command -v python3 &>/dev/null; then
-        fail "python3 is required to fetch release info"
+    local install_dir
+    install_dir=$(get_plugin_install_dir)
+    mkdir -p "$(dirname "$install_dir")"
+    info "Installing to $install_dir"
+    if [[ -d "$install_dir" ]]; then
+        rm -rf "$install_dir"
     fi
-    local tmp_dir
-    tmp_dir="$(mktemp -d)"
-    trap 'rm -rf "$tmp_dir"' EXIT
-    local meta_file="$tmp_dir/release.json"
-    if ! curl -fsSL "$GITHUB_API_URL" -o "$meta_file"; then
-        fail "Failed to fetch latest release metadata"
-    fi
-    local latest_tag asset_url
-    mapfile -t release_info < <(
-        python3 - "$meta_file" "$RELEASE_ASSET_NAME" <<'PY'
+    mkdir -p "$install_dir"
+
+    if $INSTALL_LOCAL; then
+        info "Installing LuaTools plugin from local workspace..."
+        local script_dir
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        if [[ -f "$script_dir/plugin.json" && -d "$script_dir/backend" && -d "$script_dir/public" ]]; then
+            cp -r "$script_dir/backend" "$install_dir/backend"
+            cp -r "$script_dir/public" "$install_dir/public"
+            cp "$script_dir/plugin.json" "$install_dir/plugin.json"
+            ok "Plugin installed (version local workspace)"
+        else
+            fail "Local workspace files (plugin.json, backend, public) not found in $script_dir."
+        fi
+    else
+        info "Installing LuaTools plugin from latest GitHub release..."
+        if ! command -v python3 &>/dev/null; then
+            fail "python3 is required to fetch release info"
+        fi
+        local tmp_dir
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+        local meta_file="$tmp_dir/release.json"
+        if ! curl -fsSL "$GITHUB_API_URL" -o "$meta_file"; then
+            fail "Failed to fetch latest release metadata"
+        fi
+        local latest_tag asset_url
+        mapfile -t release_info < <(
+            python3 - "$meta_file" "$RELEASE_ASSET_NAME" <<'PY'
 import json, sys
 meta_file = sys.argv[1]
 asset_name = sys.argv[2]
@@ -85,30 +108,23 @@ for asset in data.get('assets', []):
 print(tag)
 print(asset_url)
 PY
-    )
-    latest_tag="${release_info[0]}"
-    asset_url="${release_info[1]}"
-    if [[ -z "$asset_url" ]]; then
-        fail "Release asset '$RELEASE_ASSET_NAME' not found"
+        )
+        latest_tag="${release_info[0]}"
+        asset_url="${release_info[1]}"
+        if [[ -z "$asset_url" ]]; then
+            fail "Release asset '$RELEASE_ASSET_NAME' not found"
+        fi
+        info "Latest release: ${latest_tag:-unknown}"
+        local zip_file="$tmp_dir/$RELEASE_ASSET_NAME"
+        info "Downloading $RELEASE_ASSET_NAME ..."
+        if ! curl -fL "$asset_url" -o "$zip_file"; then
+            fail "Download failed"
+        fi
+        if ! extract_zip "$zip_file" "$install_dir"; then
+            fail "Extraction failed"
+        fi
+        ok "Plugin installed (version ${latest_tag:-latest})"
     fi
-    info "Latest release: ${latest_tag:-unknown}"
-    local zip_file="$tmp_dir/$RELEASE_ASSET_NAME"
-    info "Downloading $RELEASE_ASSET_NAME ..."
-    if ! curl -fL "$asset_url" -o "$zip_file"; then
-        fail "Download failed"
-    fi
-    local install_dir
-    install_dir=$(get_plugin_install_dir)
-    mkdir -p "$(dirname "$install_dir")"
-    info "Installing to $install_dir"
-    if [[ -d "$install_dir" ]]; then
-        rm -rf "$install_dir"
-    fi
-    mkdir -p "$install_dir"
-    if ! extract_zip "$zip_file" "$install_dir"; then
-        fail "Extraction failed"
-    fi
-    ok "Plugin installed (version ${latest_tag:-latest})"
 }
 
 # ---------- Helper: get plugin install dir ----------
@@ -993,12 +1009,23 @@ interactive_menu() {
 
 # ---------- Entry point ----------
 main() {
+    local filtered_args=()
     for arg in "$@"; do
         if [[ "$arg" == "--debug" ]]; then
             DEBUG=true
             set -x
+        elif [[ "$arg" == "--local" ]]; then
+            INSTALL_LOCAL=true
+        else
+            filtered_args+=("$arg")
         fi
     done
+    if [[ ${#filtered_args[@]} -gt 0 ]]; then
+        set -- "${filtered_args[@]}"
+    else
+        set -- ""
+    fi
+
     require_cmd curl
     require_cmd bash
     if ! command -v git >/dev/null; then
@@ -1021,7 +1048,7 @@ main() {
         --cancel)              info "Cancelled." ; exit 0 ;;
         -h|--help)
             cat <<'EOF'
-Usage: install.sh [option] [--debug]
+Usage: install.sh [option] [--debug] [--local]
 
 Options:
     1, --install-all       Install all (Millennium beta + plugin + accela standard)
@@ -1033,6 +1060,7 @@ Options:
     7, --uninstall         Uninstall everything
     --cancel               Exit
     --debug                Enable debug output
+    --local                Install from local workspace instead of GitHub
     -h, --help             Show this help
 EOF
             exit 0

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,22 @@ PY
     if ! curl -fL "$asset_url" -o "$zip_file"; then
         fail "Download failed"
     fi
+    local install_dir
+    install_dir=$(get_plugin_install_dir)
+    mkdir -p "$(dirname "$install_dir")"
+    info "Installing to $install_dir"
+    if [[ -d "$install_dir" ]]; then
+        rm -rf "$install_dir"
+    fi
+    mkdir -p "$install_dir"
+    if ! extract_zip "$zip_file" "$install_dir"; then
+        fail "Extraction failed"
+    fi
+    ok "Plugin installed (version ${latest_tag:-latest})"
+}
+
+# ---------- Helper: get plugin install dir ----------
+get_plugin_install_dir() {
     local millennium_dir=""
     local candidates=(
         "$HOME/.local/share/millennium/plugins"
@@ -112,19 +128,89 @@ PY
     done
     if [[ -z "$millennium_dir" ]]; then
         millennium_dir="$HOME/.local/share/millennium/plugins"
-        mkdir -p "$millennium_dir"
-        warn "Created plugins directory at $millennium_dir"
     fi
-    local install_dir="$millennium_dir/$PLUGIN_NAME"
-    info "Installing to $install_dir"
-    if [[ -d "$install_dir" ]]; then
-        rm -rf "$install_dir"
+    echo "$millennium_dir/$PLUGIN_NAME"
+}
+
+# ---------- Helper: ensure venv module is installed on the system ----------
+ensure_venv_module_installed() {
+    if python3 -c "import venv" &>/dev/null; then
+        return 0
     fi
-    mkdir -p "$install_dir"
-    if ! extract_zip "$zip_file" "$install_dir"; then
-        fail "Extraction failed"
+    
+    warn "python3-venv module is not available. Attempting to install it..."
+    local family=$(get_distro_family)
+    case "$family" in
+        debian)
+            info "Installing python3-venv via apt..."
+            sudo apt-get update && sudo apt-get install -y python3-venv
+            ;;
+        fedora)
+            info "Installing python3-virtualenv via dnf..."
+            sudo dnf install -y python3-virtualenv
+            ;;
+        arch)
+            info "Installing python via pacman..."
+            sudo pacman -S --noconfirm python
+            ;;
+        *)
+            fail "Could not automatically install python3-venv. Please install the virtualenv/venv package for python3 manually."
+            ;;
+    esac
+    
+    if ! python3 -c "import venv" &>/dev/null; then
+        fail "Failed to install/verify python3 venv module."
     fi
-    ok "Plugin installed (version ${latest_tag:-latest})"
+    ok "python3 venv module is ready."
+}
+
+# ---------- Helper: inject venv site-packages into main.py ----------
+inject_venv_into_main_py() {
+    local install_dir
+    install_dir=$(get_plugin_install_dir)
+    local main_py="$install_dir/backend/main.py"
+    
+    if [[ ! -f "$main_py" ]]; then
+        warn "main.py not found at $main_py, skipping venv injection."
+        return
+    fi
+    
+    # Check if we already injected it to avoid duplicates
+    if grep -q "VENV SITE-PACKAGES INJECTION" "$main_py"; then
+        ok "venv injection already present in main.py."
+        return
+    fi
+    
+    info "Injecting venv site-packages into main.py..."
+    local tmp_file
+    tmp_file=$(mktemp)
+    
+    cat << 'EOF' > "$tmp_file"
+# === VENV SITE-PACKAGES INJECTION ===
+import sys
+import os
+try:
+    backend_dir = os.path.dirname(os.path.abspath(__file__))
+    plugin_root = os.path.dirname(backend_dir)
+    venv_path = os.path.join(plugin_root, ".venv")
+    if os.path.exists(venv_path):
+        lib_dir = os.path.join(venv_path, "lib")
+        if os.path.exists(lib_dir):
+            for py_dir in os.listdir(lib_dir):
+                site_packages = os.path.join(lib_dir, py_dir, "site-packages")
+                if os.path.exists(site_packages):
+                    if site_packages not in sys.path:
+                        sys.path.insert(0, site_packages)
+                    break
+except Exception as e:
+    pass
+# ====================================
+EOF
+    
+    cat "$main_py" >> "$tmp_file"
+    mv "$tmp_file" "$main_py"
+    chmod +x "$main_py"
+    ok "main.py patched successfully."
 }
 
 # ---------- Python dependency check and installation (only for plugin) ----------

--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,152 @@ get_plugin_install_dir() {
     echo "$millennium_dir/$PLUGIN_NAME"
 }
 
+# ---------- Helper: enable plugin in Millennium config.json ----------
+enable_plugin_in_config() {
+    local config_dir="$HOME/.config/millennium"
+    local config_file="$config_dir/config.json"
+    
+    info "Ensuring LuaTools is enabled in Millennium config.json..."
+    
+    if [[ ! -d "$config_dir" ]]; then
+        mkdir -p "$config_dir"
+    fi
+    
+    if [[ ! -f "$config_file" ]]; then
+        cat << 'EOF' > "$config_file"
+{
+  "general": {
+    "accentColor": "DEFAULT_ACCENT_COLOR",
+    "checkForMillenniumUpdates": true,
+    "checkForPluginAndThemeUpdates": true,
+    "injectCSS": true,
+    "injectJavascript": true,
+    "millenniumUpdateChannel": "stable",
+    "onMillenniumUpdate": 1,
+    "shouldShowThemePluginUpdateNotifications": true
+  },
+  "misc": {
+    "hasShownWelcomeModal": true
+  },
+  "notifications": {
+    "showNotifications": true,
+    "showPluginNotifications": true,
+    "showUpdateNotifications": true
+  },
+  "plugins": {
+    "enabledPlugins": [
+      "luatools"
+    ]
+  },
+  "themes": {
+    "activeTheme": "default",
+    "allowedScripts": true,
+    "allowedStyles": true
+  }
+}
+EOF
+        ok "Created new Millennium config.json with luatools enabled."
+        return 0
+    fi
+    
+    if command -v python3 &>/dev/null; then
+        python3 - "$config_file" <<'PY'
+import json, sys
+file_path = sys.argv[1]
+try:
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+except Exception:
+    data = {}
+
+if 'plugins' not in data:
+    data['plugins'] = {}
+enabled = data['plugins'].get('enabledPlugins', [])
+if 'luatools' not in enabled:
+    enabled.append('luatools')
+data['plugins']['enabledPlugins'] = enabled
+
+with open(file_path, 'w', encoding='utf-8') as f:
+    json.dump(data, f, indent=2)
+PY
+        ok "Enabled luatools in existing Millennium config.json."
+    else
+        if command -v jq &>/dev/null; then
+            local tmp_cfg
+            tmp_cfg=$(mktemp)
+            jq '.plugins.enabledPlugins = (.plugins.enabledPlugins + ["luatools"] | unique)' "$config_file" > "$tmp_cfg" && mv "$tmp_cfg" "$config_file"
+            ok "Enabled luatools in existing Millennium config.json using jq."
+        else
+            warn "python3/jq not available to safely edit config.json. Please ensure luatools is enabled manually in Millennium settings."
+        fi
+    fi
+}
+
+# ---------- Helper: configure launcher path automatically ----------
+configure_launcher_path() {
+    local install_dir
+    install_dir=$(get_plugin_install_dir)
+    local data_dir="$install_dir/backend/data"
+    local path_file="$data_dir/launcher_path.txt"
+    
+    info "Detecting ACCELA path to configure LuaTools automatically..."
+    
+    local accela_candidates=(
+        "$HOME/.local/share/ACCELA"
+        "$HOME/accela"
+    )
+    local files=(
+        "ACCELA.AppImage"
+        "run.sh"
+    )
+    
+    local detected_path=""
+    for dir in "${accela_candidates[@]}"; do
+        for f in "${files[@]}"; do
+            if [[ -f "$dir/$f" ]]; then
+                detected_path="$dir/$f"
+                break 2
+            fi
+        done
+    done
+    
+    if [[ -n "$detected_path" ]]; then
+        mkdir -p "$data_dir"
+        echo "$detected_path" > "$path_file"
+        ok "Configured launcher path to: $detected_path"
+    else
+        warn "ACCELA executable (ACCELA.AppImage or run.sh) not found. You will need to select it manually in the LuaTools settings."
+    fi
+}
+
+# ---------- Helper: enable PlayNotOwnedGames in SLSsteam config ----------
+configure_play_not_owned() {
+    local config_dir="$HOME/.config/SLSsteam"
+    local config_file="$config_dir/config.yaml"
+    
+    info "Setting PlayNotOwnedGames to yes in SLSsteam config.yaml..."
+    
+    if [[ ! -d "$config_dir" ]]; then
+        mkdir -p "$config_dir"
+    fi
+    
+    if [[ ! -f "$config_file" ]]; then
+        cat << 'EOF' > "$config_file"
+PlayNotOwnedGames: yes
+SafeMode: no
+EOF
+        ok "Created new SLSsteam config.yaml with PlayNotOwnedGames enabled."
+        return 0
+    fi
+    
+    if grep -q "^PlayNotOwnedGames:" "$config_file"; then
+        sed -i 's/^PlayNotOwnedGames:.*/PlayNotOwnedGames: yes/' "$config_file"
+    else
+        echo "PlayNotOwnedGames: yes" >> "$config_file"
+    fi
+    ok "Enabled PlayNotOwnedGames in existing SLSsteam config.yaml."
+}
+
 # ---------- Helper: ensure venv module is installed on the system ----------
 ensure_venv_module_installed() {
     if python3 -c "import venv" &>/dev/null; then
@@ -294,30 +440,6 @@ show_status() {
     else
         warn "Accela: NOT installed"
     fi
-}
-
-# ---------- Post-install instructions ----------
-show_post_install_instructions() {
-    if ! is_accela_installed; then
-        return
-    fi
-    echo ""
-    echo -e "${BOLD}${YELLOW}+----------------------------------------------------------------------+${NC}"
-    echo -e "${BOLD}${YELLOW}|                    IMPORTANT: Accela Configuration                    |${NC}"
-    echo -e "${BOLD}${YELLOW}+----------------------------------------------------------------------+${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  1) Open accela, config options/downloads.                           ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  2) Ensure the option ${BOLD}\"Limit downloads to Steam Library\"${NC} is ${BOLD}ENABLED${NC}.              ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  3) In Steam, click the Steam name at the top-left corner.          ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}     Open Millennium → Plugins tab → Enable ${BOLD}LuaTools${NC}.                    ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  4) Go to Lua tools menu on Steam/config ${BOLD}\"External Launcher (ACCELA)\"${NC}               ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}     and click the folder icon.                                        ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  5) Navigate to ${BOLD}~/.local/share/ACCELA${NC} and select:                                   ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}       - ${GREEN}run.sh${NC} (if installed as script) or                                     ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}       - ${GREEN}ACCELA.AppImage${NC} (if using AppImage)                                  ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  6) Click the save icon (diskette).                                      ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}|${NC}  7) You can now add your game directly from the game page.                ${BOLD}${YELLOW}|${NC}"
-    echo -e "${BOLD}${YELLOW}+----------------------------------------------------------------------+${NC}"
-    echo ""
 }
 
 # ---------- Pre-flight checks ----------
@@ -631,6 +753,9 @@ install_millennium_legacy() {
     curl -fsSL "https://github.com/SteamClientHomebrew/Millennium/raw/refs/heads/legacy/scripts/install.sh" | bash || fail "Millennium Legacy installation failed."
     ok "Millennium Legacy installed"
     install_plugin_from_release
+    enable_plugin_in_config
+    configure_launcher_path
+    configure_play_not_owned
     check_python_dependencies
     start_steam
     info "Millennium Legacy + plugin installation completed. Steam started."
@@ -650,7 +775,8 @@ install_legacy_accela_and_sls() {
     curl -fsSL "$LEGACY_ACCELA_REPO" | bash || fail "Legacy Accela installation failed."
     
     ok "Legacy Accela (run.sh) and SLSsteam installed successfully."
-    show_post_install_instructions
+    configure_launcher_path
+    configure_play_not_owned
 }
 
 # ---------- Option 1: Install All (beta + standard accela) ----------
@@ -660,11 +786,13 @@ install_all() {
     force_close_steam
     install_millennium_beta
     install_plugin_from_release
+    enable_plugin_in_config
     check_python_dependencies
     install_accela_and_slssteam
+    configure_launcher_path
+    configure_play_not_owned
     start_steam
     show_status
-    show_post_install_instructions
     ok "Full installation complete. Steam has been started."
 }
 
@@ -680,12 +808,12 @@ install_millennium_flow() {
         install_millennium_beta
     fi
     install_plugin_from_release
+    enable_plugin_in_config
+    configure_launcher_path
+    configure_play_not_owned
     check_python_dependencies
     start_steam
     show_status
-    if is_accela_installed; then
-        show_post_install_instructions
-    fi
     ok "Plugin installation complete. Steam has been started."
 }
 
@@ -698,8 +826,9 @@ install_millennium_legacy_flow() {
 install_accela_only() {
     info "Installing accela and slssteam only (standard AppImage version)..."
     install_accela_and_slssteam
+    configure_launcher_path
+    configure_play_not_owned
     show_status
-    show_post_install_instructions
     ok "Accela installation completed."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -220,47 +220,34 @@ check_python_dependencies() {
         warn "python3 not found. Cannot check dependencies."
         return 1
     fi
-    if python3 -c "import httpx, bs4, ruamel.yaml" 2>/dev/null; then
-        ok "All Python dependencies are already satisfied."
-        return 0
-    fi
-    warn "Some Python dependencies are missing. Attempting to install them..."
     
-    local pip_cmd=""
-    if command -v pip3 &>/dev/null; then
-        pip_cmd="pip3"
-    elif command -v pip &>/dev/null; then
-        pip_cmd="pip"
-    else
-        warn "pip not found. Trying to install pip via ensurepip..."
-        python3 -m ensurepip --upgrade 2>/dev/null || {
-            warn "Could not install pip. Please install pip manually."
-            return 1
-        }
-        pip_cmd="python3 -m pip"
+    ensure_venv_module_installed
+    
+    local install_dir
+    install_dir=$(get_plugin_install_dir)
+    local venv_dir="$install_dir/.venv"
+    
+    info "Setting up Python virtual environment in $venv_dir..."
+    if [[ ! -d "$venv_dir" ]]; then
+        python3 -m venv "$venv_dir" || fail "Failed to create virtual environment"
     fi
     
-    local packages=("httpx==0.27.2" "beautifulsoup4" "ruamel.yaml==0.18.6")
-    for pkg in "${packages[@]}"; do
-        info "Installing $pkg ..."
-        if $pip_cmd install --user "$pkg" &>/dev/null; then
-            ok "Installed $pkg"
-        else
-            warn "Failed to install $pkg. Trying without --user..."
-            if $pip_cmd install "$pkg" &>/dev/null; then
-                ok "Installed $pkg (system-wide)"
-            else
-                warn "Could not install $pkg. Manual installation may be required."
-            fi
-        fi
-    done
+    info "Installing Python dependencies inside the virtual environment..."
+    if ! "$venv_dir/bin/pip" install --upgrade pip &>/dev/null; then
+        warn "Failed to upgrade pip inside venv. Continuing..."
+    fi
     
-    if python3 -c "import httpx, bs4, ruamel.yaml" 2>/dev/null; then
-        ok "Python dependencies successfully installed."
+    if ! "$venv_dir/bin/pip" install "httpx==0.27.2" "beautifulsoup4" "ruamel.yaml==0.18.6" &>/dev/null; then
+        warn "Failed to install dependencies via pip inside venv. Retrying with verbose output..."
+        "$venv_dir/bin/pip" install "httpx==0.27.2" "beautifulsoup4" "ruamel.yaml==0.18.6" || fail "Failed to install dependencies"
+    fi
+    
+    if "$venv_dir/bin/python" -c "import httpx, bs4, ruamel.yaml" &>/dev/null; then
+        ok "Python dependencies successfully installed in virtual environment."
+        inject_venv_into_main_py
         return 0
     else
-        warn "Python dependencies still missing. You may need to install them manually:"
-        echo "  pip install httpx beautifulsoup4 ruamel.yaml"
+        warn "Python dependencies still missing in virtual environment. Manual installation may be required."
         return 1
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,10 @@ ensure_venv_module_installed() {
             info "Installing python via pacman..."
             sudo pacman -S --noconfirm python
             ;;
+        opensuse)
+            info "Installing python3-virtualenv via zypper..."
+            sudo zypper install -y python3-virtualenv
+            ;;
         *)
             fail "Could not automatically install python3-venv. Please install the virtualenv/venv package for python3 manually."
             ;;
@@ -366,6 +370,8 @@ get_distro_family() {
             echo "fedora"
         elif [[ "$ID" == "arch" || "$ID_LIKE" =~ arch ]]; then
             echo "arch"
+        elif [[ "$ID" =~ opensuse || "$ID_LIKE" =~ opensuse ]]; then
+            echo "opensuse"
         else
             echo "unknown"
         fi

--- a/plugin.json
+++ b/plugin.json
@@ -2,8 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/SteamClientHomebrew/Millennium/main/src/sys/plugin-schema.json",
   "name": "luatools",
   "common_name": "LuaToolsLinux",
-  "description": "LuaTools Steam Plugin! FOR LINUX!!! by StarWarsK and geovanygrdt",
-  "version": "1.0",
+  "description": "LuaTools Steam Plugin! FOR LINUX!! by StarWarsK and geovanygrdt",
+  "version": "1.8",
+  "backendType": "lua",
   "include": [
     "public"
   ]


### PR DESCRIPTION
# Description

This Pull Request transitions the LuaTools plugin backend to Millennium's Lua VM format (`backendType: "lua"`) and introduces automatic configuration for Millennium, ACCELA, and SLSsteam. It also refactors the Python dependency system to run safely inside a local virtual environment (`venv`) to comply with PEP 668 on modern Linux distributions.

### Key Changes:

1. **Python Dependency Isolation (venv)**:
   - Configures a local Python virtual environment (`.venv`) inside the plugin folder.
   - Automatically installs required dependencies (`httpx`, `beautifulsoup4`, `ruamel.yaml`) into the `.venv` at install time.
   - Dynamically injects the venv's `site-packages` path into `sys.path` inside `main.py` so the Millennium python process can import them without requiring global installation (which fails on modern Linux distros due to PEP 668).
   - Added `zypper` package installation support for OpenSUSE systems.

2. **Lua Backend Integration**:
   - Added `main.lua` as the plugin entry point to manage JS/CSS injection, copy assets, and run the Python bridge server in the background.
   - Synchronized `plugin.json` metadata and bumped version to `1.8`.

3. **Installer Flag for Local Development**:
   - Added `--local` flag to `install.sh` to allow developers to deploy changes directly from the local workspace instead of pulling releases from GitHub.

4. **Auto-Configuration for Launchers & Licensing**:
   - **Millennium Config**: Automatically registers `"luatools"` in Millennium's `config.json` (`enabledPlugins` array) so it loads immediately upon installation.
   - **ACCELA Paths**: Modified both the installer (`install.sh`) and the Python backend (`main.py`/`downloads.py`) to scan standard local directories (`~/.local/share/ACCELA/` or `~/accela/`) for the launcher (`ACCELA.AppImage` or `run.sh`).
   - **SLSsteam config**: Automatically configures `~/.config/SLSsteam/config.yaml` to enable `PlayNotOwnedGames: yes`.

5. **Bug Fix**:
   - Fixed a case-sensitivity issue in the Python backend `GetSLSPlayStatus` method which was failing to read `PlayNotOwnedGames` state from the SLSsteam configuration.

### Developer/Testing Note:
> [!IMPORTANT]
> When testing these changes locally, run the installer with the `--local` flag:
> ```bash
> bash install.sh --local
> ```
> Without the `--local` flag, the script downloads the latest released plugin zip from GitHub, which does not contain the new Lua backend and configuration features introduced in this PR.
